### PR TITLE
feat: Implementa la gestión de ubicaciones en el almacén

### DIFF
--- a/backend/src/controllers/ubicacionController.js
+++ b/backend/src/controllers/ubicacionController.js
@@ -2,6 +2,7 @@ const UbicacionService = require('../services/ubicacionService');
 const ResponseHelper = require('../utils/responseHelper');
 
 class UbicacionController {
+  // Crear una ubicación
   static async createUbicacion(req, res) {
     try {
       const usuario = req.user?.id || 'sistema';
@@ -12,6 +13,7 @@ class UbicacionController {
     }
   }
 
+  // Listar ubicaciones con filtros y paginación
   static async getUbicaciones(req, res) {
     try {
       const { page = 1, limit = 10, nombre_ubicacion, estado } = req.query;
@@ -27,6 +29,17 @@ class UbicacionController {
     }
   }
 
+  // Listar ubicaciones activas sin paginación ni filtros
+  static async getUbicacionesActivas(req, res) {
+    try {
+      const ubicaciones = await UbicacionService.findAllActivas();
+      return ResponseHelper.success(res, ubicaciones, 'Ubicaciones activas obtenidas exitosamente');
+    } catch (error) {
+      return ResponseHelper.error(res, error.message);
+    }
+  }
+
+  // Actualizar una ubicación
   static async updateUbicacion(req, res) {
     try {
       const { id } = req.params;
@@ -38,6 +51,7 @@ class UbicacionController {
     }
   }
 
+  // Activar / desactivar una ubicación
   static async setEstadoUbicacion(req, res) {
     try {
       const { id } = req.params;

--- a/backend/src/models/ubicacionModel.js
+++ b/backend/src/models/ubicacionModel.js
@@ -68,6 +68,18 @@ class UbicacionModel {
     const [result] = await db.execute(sql, [estado, id]);
     return result.affectedRows > 0;
   }
+  
+  static async findAllActivas() {
+  const sql = `SELECT id_ubicacion, nombre_ubicacion 
+               FROM ubicacion 
+               WHERE estado = 1 
+               ORDER BY nombre_ubicacion ASC`;
+  const [rows] = await db.query(sql);
+  return rows;
+}
+
+
+
 }
 
 module.exports = UbicacionModel;

--- a/backend/src/routes/ubicacionRoutes.js
+++ b/backend/src/routes/ubicacionRoutes.js
@@ -10,5 +10,8 @@ router.post('/', UbicacionController.createUbicacion);
 router.put('/:id', UbicacionController.updateUbicacion);
 // Activar/desactivar ubicación (soft delete)
 router.patch('/:id/estado', UbicacionController.setEstadoUbicacion);
+// Listar solo ubicaciones activas
+router.get('/activas', UbicacionController.getUbicacionesActivas);
+
 
 module.exports = router;

--- a/backend/src/services/ubicacionService.js
+++ b/backend/src/services/ubicacionService.js
@@ -1,49 +1,76 @@
 const UbicacionModel = require('../models/ubicacionModel');
-const AuditoriaModel = require('../models/auditoriaModel'); // Debes crear este modelo si no existe
+const AuditoriaModel = require('../models/auditoriaModel'); // Asegúrate de tener este modelo creado
 
 class UbicacionService {
+  // Crear ubicación
   static async createUbicacion(data, usuario) {
     if (!data.nombre_ubicacion) throw new Error('El nombre de la ubicación es obligatorio.');
-    if (data.capacidad === undefined || data.capacidad === null || isNaN(Number(data.capacidad))) throw new Error('La capacidad es obligatoria.');
+    if (data.capacidad === undefined || data.capacidad === null || isNaN(Number(data.capacidad))) {
+      throw new Error('La capacidad es obligatoria.');
+    }
     if (Number(data.capacidad) <= 0) throw new Error('La capacidad debe ser mayor a 0.');
+
     const exists = await UbicacionModel.existsByNombre(data.nombre_ubicacion);
     if (exists) throw new Error('Ya existe una ubicación con ese nombre.');
+
     const id = await UbicacionModel.create(data);
+
     await AuditoriaModel.registrar('ubicacion', id, 'crear', usuario);
+
     return await UbicacionModel.findById(id);
   }
 
+  // Listar ubicaciones con paginación y filtros
   static async getUbicaciones({ page = 1, limit = 10, nombre_ubicacion, estado }) {
     const offset = (page - 1) * limit;
+
     const ubicaciones = await UbicacionModel.findAll({ offset, limit, nombre_ubicacion, estado });
     const totalItems = await UbicacionModel.count({ nombre_ubicacion, estado });
+
     return {
       ubicaciones,
       totalItems,
       totalPages: Math.ceil(totalItems / limit),
-      currentPage: page
+      currentPage: page,
     };
   }
 
+  // Actualizar ubicación
   static async updateUbicacion(id, data, usuario) {
     const ubicacion = await UbicacionModel.findById(id);
     if (!ubicacion) throw new Error('Ubicación no encontrada.');
+
     if (!data.nombre_ubicacion) throw new Error('El nombre de la ubicación es obligatorio.');
-    if (data.capacidad === undefined || data.capacidad === null || isNaN(Number(data.capacidad))) throw new Error('La capacidad es obligatoria.');
+    if (data.capacidad === undefined || data.capacidad === null || isNaN(Number(data.capacidad))) {
+      throw new Error('La capacidad es obligatoria.');
+    }
     if (Number(data.capacidad) <= 0) throw new Error('La capacidad debe ser mayor a 0.');
+
     const exists = await UbicacionModel.existsByNombre(data.nombre_ubicacion, id);
     if (exists) throw new Error('Ya existe una ubicación con ese nombre.');
+
     await UbicacionModel.update(id, data);
+
     await AuditoriaModel.registrar('ubicacion', id, 'editar', usuario);
+
     return await UbicacionModel.findById(id);
   }
 
+  // Activar / Desactivar ubicación
   static async setEstadoUbicacion(id, estado, usuario) {
     const ubicacion = await UbicacionModel.findById(id);
     if (!ubicacion) throw new Error('Ubicación no encontrada.');
+
     await UbicacionModel.setEstado(id, estado);
+
     await AuditoriaModel.registrar('ubicacion', id, estado ? 'activar' : 'desactivar', usuario);
+
     return await UbicacionModel.findById(id);
+  }
+
+  // Obtener todas las ubicaciones activas (sin paginación ni búsqueda)
+  static async findAllActivas() {
+    return await UbicacionModel.findAllActivas();
   }
 }
 


### PR DESCRIPTION
Se agrego:
servicio que retorne todas las ubicaciones sin paginacion y busqueda y que esten activos, que solo retorne un array de objetos
{
	id_ubicacion: 1,
	nombre_ubicacion: “nobre de la ubicacion”
}